### PR TITLE
Accept either multiple benchmark names or a list of names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ A charm providing this interface is providing benchmarks to the Benchmark GUI.
 This interface layer will set the following states, as appropriate:
 
   * `{relation_name}.joined` The Benchmark GUI has been related.  The charm
-    should call the `register(benchmarks)` method to register a list of
-    benchmarks with the GUI.
+    should call the `register(*benchmarks)` method to register a list of
+    benchmarks with the GUI (note: this can either be passed one or more
+    strings, e.g., `register('foo', 'bar')` or it can be passed a list,
+    e.g., `register(['foo', 'bar'])`).
 
 Example:
 

--- a/provides.py
+++ b/provides.py
@@ -29,5 +29,13 @@ class BenchmarkProvides(RelationBase):
         conv.remove_state('{relation_name}.joined')
 
     def register(self, *benchmarks):
+        """
+        Register one or more benchmarks.
+
+        :param benchmarks: One or more benchmark names, or a list
+            containing one or more benchmark names.
+        """
+        if len(benchmarks) == 1 and isinstance(benchmarks[0], (list, tuple)):
+            benchmarks = benchmarks[0]
         conv = self.conversation()
         conv.set_remote('benchmarks', ','.join(benchmarks))


### PR DESCRIPTION
This fixes a `benchmark-relation-joined` hook failure on the Spark charm

```
    conv.set_remote('benchmarks', ','.join(benchmarks))
TypeError: sequence item 0: expected str instance, list found
hook "benchmark-relation-joined" failed: exit status 1
```
